### PR TITLE
Add CircleCI quality gate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - checkout
       - run:
+          command: yarn install --frozen-lockfile
+      - run:
           command: yarn run lint:check
   pretty:
     docker:
@@ -25,11 +27,15 @@ jobs:
     steps:
       - checkout
       - run:
+          command: yarn install --frozen-lockfile
+      - run:
           command: yarn run pretty:check
   test:
     docker:
       - image: circleci/node:10.16.3
     steps:
       - checkout
+      - run:
+          command: yarn install --frozen-lockfile
       - run:
           command: yarn run test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,35 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@3.0.0
+
+workflows:
+  version: 2
+  quality-gate:
+    jobs:
+      - lint
+      - pretty
+      - test
+
+jobs:
+  lint:
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - run:
+          command: yarn run lint:check
+  pretty:
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - run:
+          command: yarn run pretty:check
+  test:
+    docker:
+      - image: circleci/node:10.16.3
+    steps:
+      - checkout
+      - run:
+          command: yarn run test


### PR DESCRIPTION
Add CircleCi config to run the tests, linting, and formatting (prettier) on each push.

Part of #5 - adds quality gate, build and release not handled by CircleCi.